### PR TITLE
Mavenlink upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ rvm:
   - 2.1.5
   - 2.2.2
 gemfile:
-  - gemfiles/activerecord-3.0
   - gemfiles/activerecord-3.1
   - gemfiles/activerecord-3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
+  - 2.1.5
+  - 2.2.2
 gemfile:
-  - gemfiles/activerecord-2.3
   - gemfiles/activerecord-3.0
   - gemfiles/activerecord-3.1
   - gemfiles/activerecord-3.2

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ ENV["AR_VERSION"] ||= "~> 2.3.5"
 gem "activerecord", ENV["AR_VERSION"], :require => "active_record"
 
 gem "rake"
-gem "rspec", "~> 1.3.0"
+gem "rspec", "~> 2.10.0"
 gem "sqlite3", "~> 1.3.1"

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source :rubygems
 
-ENV["AR_VERSION"] ||= "~> 2.3.5"
+ENV["AR_VERSION"] ||= "~> 3.2.12"
 
 gem "activerecord", ENV["AR_VERSION"], :require => "active_record"
 
 gem "rake"
 gem "rspec", "~> 2.10.0"
-gem "sqlite3", "~> 1.3.1"
+gem "sqlite3", "~> 1.3.7"

--- a/README.rdoc
+++ b/README.rdoc
@@ -48,6 +48,16 @@ Finally, you can declare your model arboreal:
       
     end
 
+If you want to customize the +parent+ and/or +children+ relations, you can pass additional relation options to +acts_arboreal+:
+
+    class Thing < ActiveRecord::Base
+
+      acts_arboreal parent_relation_options: { touch: true }, children_relation_options: { autosave: true }
+
+      # .. etc etc ...
+
+    end
+
 == Navigating the tree
 
 Arboreal adds the basic relationships you'd expect:

--- a/README.rdoc
+++ b/README.rdoc
@@ -18,20 +18,20 @@ It delegates as much work as possible to the underlying DBMS, making it efficien
 
 First, install the "arboreal" gem, and add it to your Rails project's <tt>config/environment.rb</tt>.  
 
-Next, you'll need a migration to add +parent_id+ and +ancestry_string+ columns, and indices:
+Next, you'll need a migration to add +parent_id+ and +materialized_path+ columns, and indices:
 
     class MakeThingsArboreal < ActiveRecord::Migration
 
       def self.up
         add_column "things", "parent_id", :integer
         add_index "things", ["parent_id"]
-        add_column "things", "ancestry_string", :string
-        add_index "things", ["ancestry_string"]
+        add_column "things", "materialized_path", :string
+        add_index "things", ["materialized_path"]
       end
 
       def self.down
-        remove_index "things", ["ancestry_string"]
-        remove_column "things", "ancestry_string"
+        remove_index "things", ["materialized_path"]
+        remove_column "things", "materialized_path"
         remove_index "things", ["parent_id"]
         remove_column "things", "parent_id"
       end
@@ -72,7 +72,7 @@ At the class-level:
 
 == Rebuilding the ancestry cache
  
-Internally, Arboreal uses the +ancestry_string+ column to cache the path down the tree to each node (or more correctly, it's parent.  This technique - a variant of "path enumeration" or "materialized paths" - allows efficient retrieval of both ancestors and descendants.
+Internally, Arboreal uses the +materialized_path+ column to cache the path down the tree to each node (or more correctly, it's parent.  This technique - a variant of "path enumeration" or "materialized paths" - allows efficient retrieval of both ancestors and descendants.
 
 It's conceivable that the computed ancestry-string values may get out of whack, particularly if changes are made directly to the database.  If you suspect corruption, you can restore sanity using <tt>rebuild_ancestry</tt>, e.g
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,6 @@
-require 'bundler'
-Bundler::GemHelper.install_tasks
+#!/usr/bin/env rake
+require "bundler/gem_tasks"
 
+require "rspec/core/rake_task"
+RSpec::Core::RakeTask.new(:spec)
 task :default => :spec
-
-require "spec/rake/spectask"
-
-Spec::Rake::SpecTask.new(:spec) do |spec|
-  spec.libs << 'lib' << 'spec'
-  spec.spec_files = FileList['spec/**/*_spec.rb']
-  spec.spec_opts << "-fnested" << "--color"
-end

--- a/arboreal.gemspec
+++ b/arboreal.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--title", "Arboreal", "--main", "README.rdoc"]
   s.require_path     = "lib"
   s.files            = Dir["lib/**/*", "spec/**/*", "Rakefile"] + s.extra_rdoc_files
-  s.add_runtime_dependency("activerecord", "~> 3.0")
-  s.add_runtime_dependency("activesupport", "~> 3.0")
+  s.add_runtime_dependency("activerecord", "~> 3.1")
+  s.add_runtime_dependency("activesupport", "~> 3.1")
 end

--- a/arboreal.gemspec
+++ b/arboreal.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.name             = "arboreal"
   s.version          = Arboreal::VERSION.dup
   s.platform         = Gem::Platform::RUBY
-  s.required_ruby_version = ">= 1.8.7"
+  s.required_ruby_version = ">= 1.9.3"
   s.summary          = "Efficient tree structures for ActiveRecord"
   s.description      = description
   s.author           = "Mike Williams"

--- a/arboreal.gemspec
+++ b/arboreal.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--title", "Arboreal", "--main", "README.rdoc"]
   s.require_path     = "lib"
   s.files            = Dir["lib/**/*", "spec/**/*", "Rakefile"] + s.extra_rdoc_files
-  s.add_runtime_dependency("activerecord", ">= 2.3.0")
-  s.add_runtime_dependency("activesupport", ">= 2.3.0")
+  s.add_runtime_dependency("activerecord", "~> 3.0")
+  s.add_runtime_dependency("activesupport", "~> 3.0")
 end

--- a/arboreal.gemspec
+++ b/arboreal.gemspec
@@ -1,7 +1,7 @@
 description = <<TEXT
 Arboreal is yet another extension to ActiveRecord to support tree-shaped data structures.
 
-Internally, Arboreal maintains a computed "ancestry_string" column, which caches the path from the root of
+Internally, Arboreal maintains a computed "materialized_path" column, which caches the path from the root of
 a tree to each node, allowing efficient retrieval of both ancestors and descendants.
 
 Arboreal surfaces relationships within the tree like "children", "ancestors", "descendants", and "siblings"

--- a/gemfiles/activerecord-2.3
+++ b/gemfiles/activerecord-2.3
@@ -1,3 +1,0 @@
-ENV["AR_VERSION"] = "~> 2.3.5"
-
-eval(File.read(File.expand_path("../../Gemfile", __FILE__)))

--- a/gemfiles/activerecord-3.0
+++ b/gemfiles/activerecord-3.0
@@ -1,3 +1,0 @@
-ENV["AR_VERSION"] = "~> 3.0.11"
-
-eval(File.read(File.expand_path("../../Gemfile", __FILE__)))

--- a/lib/arboreal/active_record_extensions.rb
+++ b/lib/arboreal/active_record_extensions.rb
@@ -4,9 +4,9 @@ module Arboreal
   module ActiveRecordExtensions
     # Declares that this ActiveRecord::Base model has a tree-like structure.
     def acts_arboreal(options = {})
-      belongs_to :parent, class_name: self.name, inverse_of: :children
+      belongs_to :parent, { class_name: self.name, inverse_of: :children }.merge(options[:parent_relation_options] || {})
       has_many   :children, { class_name: self.name, foreign_key: :parent_id, inverse_of: :parent }
-                              .reverse_merge(options[:children_relation_options] || {})
+                              .merge(options[:children_relation_options] || {})
 
       extend Arboreal::ClassMethods
       include Arboreal::InstanceMethods

--- a/lib/arboreal/active_record_extensions.rb
+++ b/lib/arboreal/active_record_extensions.rb
@@ -4,7 +4,7 @@ module Arboreal
   module ActiveRecordExtensions
     # Declares that this ActiveRecord::Base model has a tree-like structure.
     def acts_arboreal(options = {})
-      belongs_to :parent, class_name: self.name
+      belongs_to :parent, class_name: self.name, inverse_of: :children
       has_many   :children, { class_name: self.name, foreign_key: :parent_id, inverse_of: :parent }
                               .reverse_merge(options[:children_relation_options] || {})
 
@@ -15,9 +15,9 @@ module Arboreal
       before_save :populate_materialized_path
 
       validate :validate_parent_not_ancestor
-      validates :materialized_path, format: { with: /\A-(\d+-)*\z/, allow_nil: false, allow_blank: false }
+      validates :materialized_path, format: { with: /\A-(\d+-)*\z/, allow_nil: true, allow_blank: false }
 
-      after_save  :apply_ancestry_change_to_descendants
+      after_save :apply_ancestry_change_to_descendants
 
       scope :roots, lambda { where(parent_id: nil) }
     end

--- a/lib/arboreal/active_record_extensions.rb
+++ b/lib/arboreal/active_record_extensions.rb
@@ -2,12 +2,10 @@ require 'active_record'
 
 module Arboreal
   module ActiveRecordExtensions
-
     # Declares that this ActiveRecord::Base model has a tree-like structure.
     def acts_arboreal
-
-      belongs_to :parent, :class_name => self.name
-      has_many   :children, :class_name => self.name, :foreign_key => :parent_id
+      belongs_to :parent, class_name: self.name
+      has_many   :children, class_name: self.name, foreign_key: :parent_id
 
       extend Arboreal::ClassMethods
       include Arboreal::InstanceMethods
@@ -21,20 +19,8 @@ module Arboreal
       before_save :detect_ancestry_change
       after_save  :apply_ancestry_change_to_descendants
 
-      case ActiveRecord::VERSION::MAJOR
-
-      when 3
-        scope :roots, where(:parent_id => nil)
-
-      when 2
-        named_scope :roots, {
-          :conditions => ["parent_id IS NULL"]
-        }
-
-      end
-
+      scope :roots, lambda { where(parent_id: nil) }
     end
-
   end
 end
 

--- a/lib/arboreal/active_record_extensions.rb
+++ b/lib/arboreal/active_record_extensions.rb
@@ -5,16 +5,17 @@ module Arboreal
     # Declares that this ActiveRecord::Base model has a tree-like structure.
     def acts_arboreal(options = {})
       belongs_to :parent, class_name: self.name
-      has_many   :children, { class_name: self.name, foreign_key: :parent_id }.reverse_merge(options[:children_relation_options] || {})
+      has_many   :children, { class_name: self.name, foreign_key: :parent_id, inverse_of: :parent }
+                              .reverse_merge(options[:children_relation_options] || {})
 
       extend Arboreal::ClassMethods
       include Arboreal::InstanceMethods
 
-      before_validation :populate_ancestry_string
-      before_save :populate_ancestry_string
+      before_validation :populate_materialized_path
+      before_save :populate_materialized_path
 
       validate :validate_parent_not_ancestor
-      validates :ancestry_string, format: { with: /\A-(\d+-)*\z/, allow_nil: false, allow_blank: false }
+      validates :materialized_path, format: { with: /\A-(\d+-)*\z/, allow_nil: false, allow_blank: false }
 
       after_save  :apply_ancestry_change_to_descendants
 

--- a/lib/arboreal/active_record_extensions.rb
+++ b/lib/arboreal/active_record_extensions.rb
@@ -15,7 +15,7 @@ module Arboreal
       before_save :populate_materialized_path
 
       validate :validate_parent_not_ancestor
-      validates :materialized_path, format: { with: /\A-(\d+-)*\z/, allow_nil: true, allow_blank: false }
+      validates :materialized_path, format: { with: /\A-(\d+-)*\z/, allow_nil: false, allow_blank: false }
 
       after_save :apply_ancestry_change_to_descendants
 

--- a/lib/arboreal/active_record_extensions.rb
+++ b/lib/arboreal/active_record_extensions.rb
@@ -3,9 +3,9 @@ require 'active_record'
 module Arboreal
   module ActiveRecordExtensions
     # Declares that this ActiveRecord::Base model has a tree-like structure.
-    def acts_arboreal
+    def acts_arboreal(options = {})
       belongs_to :parent, class_name: self.name
-      has_many   :children, class_name: self.name, foreign_key: :parent_id
+      has_many   :children, { class_name: self.name, foreign_key: :parent_id }.reverse_merge(options[:children_relation_options] || {})
 
       extend Arboreal::ClassMethods
       include Arboreal::InstanceMethods

--- a/lib/arboreal/active_record_extensions.rb
+++ b/lib/arboreal/active_record_extensions.rb
@@ -11,12 +11,11 @@ module Arboreal
       include Arboreal::InstanceMethods
 
       before_validation :populate_ancestry_string
+      before_save :populate_ancestry_string
 
-      validate do |record|
-        record.send(:validate_parent_not_ancestor)
-      end
+      validate :validate_parent_not_ancestor
+      validates :ancestry_string, format: { with: /\A-(\d+-)*\z/, allow_nil: false, allow_blank: false }
 
-      before_save :detect_ancestry_change
       after_save  :apply_ancestry_change_to_descendants
 
       scope :roots, lambda { where(parent_id: nil) }

--- a/lib/arboreal/active_record_extensions.rb
+++ b/lib/arboreal/active_record_extensions.rb
@@ -17,7 +17,7 @@ module Arboreal
       validate :validate_parent_not_ancestor
       validates :materialized_path, format: { with: /\A-(\d+-)*\z/, allow_nil: false, allow_blank: false }
 
-      after_save :apply_ancestry_change_to_descendants
+      after_update :apply_ancestry_change_to_descendants
 
       scope :roots, lambda { where(parent_id: nil) }
     end

--- a/lib/arboreal/class_methods.rb
+++ b/lib/arboreal/class_methods.rb
@@ -3,30 +3,30 @@ require "active_support/core_ext/string/filters"
 module Arboreal
   module ClassMethods
     
-    # Discard existing ancestry_strings and recompute them from parent relationships.
+    # Discard existing materialized_paths and recompute them from parent relationships.
     def rebuild_ancestry
-      clear_ancestry_strings
-      populate_root_ancestry_strings
+      clear_materialized_paths
+      populate_root_materialized_paths
       begin
-        n_changes = extend_ancestry_strings 
+        n_changes = extend_materialized_paths
       end until n_changes.zero?
     end
     
     private
     
-    def clear_ancestry_strings
-      connection.update("UPDATE #{table_name} SET ancestry_string = NULL")
+    def clear_materialized_paths
+      connection.update("UPDATE #{table_name} SET materialized_path = NULL")
     end
 
-    def populate_root_ancestry_strings
-      connection.update("UPDATE #{table_name} SET ancestry_string = '-' WHERE parent_id IS NULL")
+    def populate_root_materialized_paths
+      connection.update("UPDATE #{table_name} SET materialized_path = '-' WHERE parent_id IS NULL")
     end
 
-    def extend_ancestry_strings
+    def extend_materialized_paths
       connection.update(ancestry_extension_sql)
     end
 
-    # Return SQL that will extend ancestry_strings one level further down the hierarchy.
+    # Return SQL that will extend materialized_paths one level further down the hierarchy.
     #
     # We use DBMS-specific SQL here, as string-concatenation operators vary.  
     # As a result, this *may* not work for DBMS that aren't explicitly supported.
@@ -36,29 +36,29 @@ module Arboreal
         <<-SQL
           UPDATE _arboreals_ AS child
           JOIN _arboreals_ AS parent ON parent.id = child.parent_id
-          SET child.ancestry_string = CONCAT(parent.ancestry_string, parent.id, '-')
-          WHERE child.ancestry_string IS NULL
-            AND parent.ancestry_string IS NOT NULL
+          SET child.materialized_path = CONCAT(parent.materialized_path, parent.id, '-')
+          WHERE child.materialized_path IS NULL
+            AND parent.materialized_path IS NOT NULL
         SQL
       elsif connection.adapter_name == "JDBC" && connection.config[:url] =~ /sqlserver/
         <<-SQL
           UPDATE child
-          SET child.ancestry_string = (parent.ancestry_string + CAST(parent.id AS varchar) + '-')
+          SET child.materialized_path = (parent.materialized_path + CAST(parent.id AS varchar) + '-')
           FROM _arboreals_ AS child
           JOIN _arboreals_ AS parent ON parent.id = child.parent_id
-          WHERE child.ancestry_string IS NULL
-            AND parent.ancestry_string IS NOT NULL
+          WHERE child.materialized_path IS NULL
+            AND parent.materialized_path IS NOT NULL
         SQL
       else # SQLite, PostgreSQL, most others (SQL-92)
         <<-SQL
           UPDATE _arboreals_
-          SET ancestry_string = (
-            SELECT (parent.ancestry_string || _arboreals_.parent_id || '-')
+          SET materialized_path = (
+            SELECT (parent.materialized_path || _arboreals_.parent_id || '-')
             FROM _arboreals_ AS parent
             WHERE parent.id = _arboreals_.parent_id
-              AND parent.ancestry_string IS NOT NULL
+              AND parent.materialized_path IS NOT NULL
           )
-          WHERE ancestry_string IS NULL
+          WHERE materialized_path IS NULL
         SQL
       end
       sql.gsub("_arboreals_", table_name).squish

--- a/lib/arboreal/instance_methods.rb
+++ b/lib/arboreal/instance_methods.rb
@@ -42,7 +42,7 @@ module Arboreal
 
     # return the root of the tree
     def root
-      ancestors.first || self
+      root? ? self : ancestors.first
     end
 
     private

--- a/lib/arboreal/instance_methods.rb
+++ b/lib/arboreal/instance_methods.rb
@@ -86,24 +86,13 @@ module Arboreal
       end
     end
 
-    def detect_ancestry_change
-      if ancestry_string_changed? && !new_record?
-        old_path_string = "#{ancestry_string_was}#{id}-"
-        @ancestry_change = [old_path_string, path_string]
-      end
-    end
-
     def apply_ancestry_change_to_descendants
-      if @ancestry_change
-        old_ancestry_string, new_ancestry_string = *@ancestry_change
-        connection.update(<<-SQL.squish)
-          UPDATE #{table_name}
-            SET ancestry_string = REPLACE(ancestry_string, '#{old_ancestry_string}', '#{new_ancestry_string}')
-            WHERE ancestry_string LIKE '#{old_ancestry_string}%'
-        SQL
-        @ancestry_change = nil
+      if ancestry_string_changed? && persisted?
+        old_path_string = "#{ancestry_string_was}#{id}-"
+        self.class
+          .where("ancestry_string like ?", old_path_string + "%")
+          .update_all ["ancestry_string = REPLACE(ancestry_string, ?, ?)", old_path_string, path_string]
       end
     end
-
   end
 end

--- a/lib/arboreal/instance_methods.rb
+++ b/lib/arboreal/instance_methods.rb
@@ -5,7 +5,7 @@ module Arboreal
 
     def path_string
       if new_record?
-        nil
+        "-"
       else
         "#{materialized_path}#{id}-"
       end
@@ -82,7 +82,7 @@ module Arboreal
 
     def validate_parent_not_ancestor
       if self.id
-        if parent_id == self.id
+        if parent == self
           errors.add(:parent, "can't be the record itself")
         end
         if ancestor_ids.include?(self.id)

--- a/lib/arboreal/instance_methods.rb
+++ b/lib/arboreal/instance_methods.rb
@@ -81,11 +81,11 @@ module Arboreal
     end
 
     def validate_parent_not_ancestor
-      if self.id
+      if persisted?
         if parent == self
           errors.add(:parent, "can't be the record itself")
         end
-        if ancestor_ids.include?(self.id)
+        if ancestor_ids.include?(id)
           errors.add(:parent, "can't be an ancestor")
         end
       end

--- a/lib/arboreal/instance_methods.rb
+++ b/lib/arboreal/instance_methods.rb
@@ -35,6 +35,11 @@ module Arboreal
       model_base_class.scoped(:conditions => sibling_conditions)
     end
 
+    # return whether or not this is a root of the tree
+    def root?
+      parent_id.nil?
+    end
+
     # return the root of the tree
     def root
       ancestors.first || self

--- a/lib/arboreal/instance_methods.rb
+++ b/lib/arboreal/instance_methods.rb
@@ -12,7 +12,7 @@ module Arboreal
     end
 
     def ancestor_ids
-      materialized_path.sub(/^-/, "").split("-").map { |x| x.to_i }
+      materialized_path.to_s.sub(/^-/, "").split("-").map { |x| x.to_i }
     end
 
     # return a scope matching all ancestors of this node

--- a/lib/arboreal/instance_methods.rb
+++ b/lib/arboreal/instance_methods.rb
@@ -92,7 +92,7 @@ module Arboreal
     end
 
     def apply_ancestry_change_to_descendants
-      if materialized_path_changed? && persisted?
+      if materialized_path_changed?
         old_path_string = "#{materialized_path_was}#{id}-"
         self.class
           .where("materialized_path like ?", old_path_string + "%")

--- a/lib/arboreal/instance_methods.rb
+++ b/lib/arboreal/instance_methods.rb
@@ -4,7 +4,11 @@ module Arboreal
   module InstanceMethods
 
     def path_string
-      "#{materialized_path}#{id}-"
+      if new_record?
+        nil
+      else
+        "#{materialized_path}#{id}-"
+      end
     end
 
     def ancestor_ids
@@ -69,9 +73,10 @@ module Arboreal
     end
 
     def populate_materialized_path
-      self.materialized_path = nil if parent_id_changed?
-      model_base_class.send(:with_exclusive_scope) do
-        self.materialized_path ||= parent ? parent.path_string : "-"
+      if parent_id_changed? || materialized_path.nil?
+        model_base_class.send(:with_exclusive_scope) do
+          self.materialized_path = parent ? parent.path_string : "-"
+        end
       end
     end
 

--- a/lib/arboreal/version.rb
+++ b/lib/arboreal/version.rb
@@ -1,3 +1,3 @@
 module Arboreal
-  VERSION = "0.2.1".freeze
+  VERSION = "0.3.0".freeze
 end

--- a/spec/arboreal_spec.rb
+++ b/spec/arboreal_spec.rb
@@ -3,11 +3,9 @@ require 'spec_helper'
 require 'arboreal'
 
 class Node < ActiveRecord::Base
-
   acts_arboreal
 
   class Migration < ActiveRecord::Migration
-
     def self.up
       create_table "nodes", :force => true do |t|
         t.string "name"
@@ -20,18 +18,15 @@ class Node < ActiveRecord::Base
     def self.down
       drop_table "nodes"
     end
-
   end
-
 end
 
 describe "Arboreal hierarchy" do
-
-  before(:all) do
+  before(:each) do
     Node::Migration.up
   end
 
-  after(:all) do
+  after(:each) do
     Node::Migration.down
   end
 
@@ -44,7 +39,6 @@ describe "Arboreal hierarchy" do
   end
 
   describe "node" do
-
     describe "#parent" do
       it "returns the parent" do
         @victoria.parent.should == @australia
@@ -74,11 +68,9 @@ describe "Arboreal hierarchy" do
         @australia.update_attributes!(:parent => @melbourne)
       end.should raise_error(ActiveRecord::RecordInvalid)
     end
-
   end
 
   describe "root node" do
-
     describe "#parent" do
       it "returns nil" do
         @australia.parent.should == nil
@@ -104,7 +96,6 @@ describe "Arboreal hierarchy" do
     end
 
     describe "#descendants" do
-
       it "includes children" do
         @australia.descendants.should include(@victoria)
         @australia.descendants.should include(@nsw)
@@ -118,11 +109,9 @@ describe "Arboreal hierarchy" do
       it "excludes self" do
         @australia.descendants.should_not include(@australia)
       end
-
     end
 
     describe "#subtree" do
-
       it "includes children" do
         @australia.subtree.should include(@victoria)
         @australia.subtree.should include(@nsw)
@@ -136,21 +125,16 @@ describe "Arboreal hierarchy" do
       it "includes self" do
         @australia.subtree.should include(@australia)
       end
-
     end
 
     describe "#root" do
-
      it "is itself" do
        @australia.root.should == @australia
      end
-
     end
-
   end
 
   describe "leaf node" do
-
     describe "#ancestry_string" do
       it "contains ids of all ancestors" do
         @melbourne.ancestry_string.should == "-#{@australia.id}-#{@victoria.id}-"
@@ -164,11 +148,9 @@ describe "Arboreal hierarchy" do
     end
 
     describe "#ancestors" do
-
       it "returns all ancestors, depth-first" do
         @melbourne.ancestors.all.should == [@australia, @victoria]
       end
-
     end
 
     describe "#children" do
@@ -184,26 +166,20 @@ describe "Arboreal hierarchy" do
     end
 
     describe "#root" do
-
       it "is the root of the tree" do
         @melbourne.root.should == @australia
       end
-
     end
-
   end
 
   describe ".roots" do
-
     it "returns root nodes" do
       @nz = Node.create!(:name => "New Zealand")
       Node.roots.to_set.should == [@australia, @nz].to_set
     end
-
   end
 
   describe "when a node changes parent" do
-
     before do
       @box_hill = Node.create!(:name => "Box Hill", :parent => @melbourne)
       @nz = Node.create!(:name => "New Zealand")
@@ -211,9 +187,7 @@ describe "Arboreal hierarchy" do
     end
 
     describe "each descendant" do
-
       it "follows" do
-
         @melbourne.reload
         @melbourne.ancestors.should include(@nz, @victoria)
         @melbourne.ancestors.should_not include(@australia)
@@ -221,15 +195,11 @@ describe "Arboreal hierarchy" do
         @box_hill.reload
         @box_hill.ancestors.should include(@nz, @victoria, @melbourne)
         @box_hill.ancestors.should_not include(@australia)
-
       end
-
     end
-
   end
 
   describe "node created using find_or_create_by" do
-
     before do
       @tasmania = @australia.children.find_or_create_by_name("Tasmania")
     end
@@ -237,11 +207,9 @@ describe "Arboreal hierarchy" do
     it "still has the right ancestry" do
       @tasmania.ancestors.should == [@australia]
     end
-
   end
 
   describe ".rebuild_ancestry" do
-
     before do
       Node.connection.update("UPDATE nodes SET ancestry_string = 'corrupt'")
       Node.rebuild_ancestry
@@ -255,9 +223,7 @@ describe "Arboreal hierarchy" do
       @melbourne.reload.ancestors.should == [@australia, @victoria]
       @sydney.reload.ancestors.should == [@australia, @nsw]
     end
-
   end
-
 end
 
 class RedNode < Node; end
@@ -265,12 +231,11 @@ class GreenNode < Node; end
 class BlueNode < Node; end
 
 describe "polymorphic hierarchy" do
-
-  before(:all) do
+  before(:each) do
     Node::Migration.up
   end
 
-  after(:all) do
+  after(:each) do
     Node::Migration.down
   end
 
@@ -297,5 +262,4 @@ describe "polymorphic hierarchy" do
       @blue.ancestors.should include(@red, @green)
     end
   end
-
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe "configuration of relations" do
+  class CustomizedNode < ActiveRecord::Base
+    self.table_name = 'nodes'
+    acts_arboreal children_relation_options: { autosave: true, dependent: :destroy }
+  end
+
+  it 'allows the user to provide options to the has_many relation' do
+    children_relation.options.should include(autosave: true)
+    children_relation.options.should include(dependent: :destroy)
+  end
+
+  def children_relation
+    reflections(CustomizedNode)["children"]
+  end
+
+  # In Rails 4.2, ActiveRecord::Base#reflections started being keyed by strings instead of symbols.
+  def reflections(klass)
+    klass.reflections.each_with_object({}) { |(key, value), memo| memo[key.to_s] = value }
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -3,12 +3,21 @@ require "spec_helper"
 describe "configuration of relations" do
   class CustomizedNode < ActiveRecord::Base
     self.table_name = 'nodes'
-    acts_arboreal children_relation_options: { autosave: true, dependent: :destroy }
+    acts_arboreal parent_relation_options: { touch: true },
+                  children_relation_options: { autosave: true, dependent: :destroy }
   end
 
   it 'allows the user to provide options to the has_many relation' do
     children_relation.options.should include(autosave: true)
     children_relation.options.should include(dependent: :destroy)
+  end
+
+  it "allows the user to provide options to the belongs_to relation" do
+    parent_relation.options.should include(touch: true)
+  end
+
+  def parent_relation
+    reflections(CustomizedNode)["parent"]
   end
 
   def children_relation

--- a/spec/dependent_saving_spec.rb
+++ b/spec/dependent_saving_spec.rb
@@ -72,6 +72,44 @@ describe "saving dependent objects" do
         end
       end
     end
+
+    context "and the child had been saved with a different parent" do
+      let(:original_parent) { Node.create!(name: "Original parent") }
+
+      before do
+        child.parent = original_parent
+        child.save!
+      end
+
+      context "when the child is saved with its new parent" do
+        before do
+          child.parent = parent
+          child.save!
+        end
+
+        it "also saves the new parent" do
+          parent.should be_persisted
+        end
+
+        it "updates the child's materialized path" do
+          child.materialized_path.should eq(parent.path_string)
+        end
+      end
+
+      context "when the parent is saved" do
+        before do
+          parent.children << child
+          parent.save!
+          parent.reload
+
+          child.reload
+        end
+
+        it "updates the child's materialized path" do
+          child.materialized_path.should eq(parent.path_string)
+        end
+      end
+    end
   end
 
   context "when the parent has been saved" do

--- a/spec/dependent_saving_spec.rb
+++ b/spec/dependent_saving_spec.rb
@@ -1,0 +1,112 @@
+require "spec_helper"
+
+describe "saving dependent objects" do
+  let(:parent) { Node.new(name: "Parent") }
+  let(:child) { Node.new(name: "Child") }
+
+  context "when the parent has not been saved" do
+    context "and the child has not been saved" do
+      context "when the child is saved" do
+        before do
+          child.parent = parent
+          child.save!
+        end
+
+        it "also saves the parent" do
+          parent.should be_persisted
+        end
+
+        it "updates the child's materialized path" do
+          child.materialized_path.should eq(parent.path_string)
+        end
+      end
+
+      context "when the parent is saved" do
+        before do
+          parent.children << child
+          parent.save!
+          child.reload
+        end
+
+        it "also saves the child" do
+          child.should be_persisted
+        end
+
+        it "updates the child's materialized path" do
+          child.materialized_path.should eq(parent.path_string)
+        end
+      end
+    end
+
+    context "and the child had been saved" do
+      before do
+        child.save!
+      end
+
+      context "when the child is saved with its new parent" do
+        before do
+          child.parent = parent
+          child.save!
+        end
+
+        it "also saves the parent" do
+          parent.should be_persisted
+        end
+
+        it "updates the child's materialized path" do
+          child.materialized_path.should eq(parent.path_string)
+        end
+      end
+
+      context "when the parent is saved" do
+        before do
+          parent.children << child
+          parent.save!
+          parent.reload
+
+          child.reload
+        end
+
+        it "updates the child's materialized path" do
+          child.materialized_path.should eq(parent.path_string)
+        end
+      end
+    end
+  end
+
+  context "when the parent has been saved" do
+    before do
+      parent.save!
+    end
+
+    context "and the child has not been saved" do
+      context "when the child is saved" do
+        before do
+          child.parent = parent
+          child.save!
+          child.reload
+        end
+
+        it "updates the child's materialized path" do
+          child.materialized_path.should eq(parent.path_string)
+        end
+      end
+
+      context "when the parent gains a new child" do
+        before do
+          parent.children << child
+          child.reload
+        end
+
+        it "saves the child" do
+          child.should be_persisted
+        end
+
+        it "updates the child's materialized path" do
+          child.materialized_path.should eq(parent.path_string)
+        end
+      end
+    end
+  end
+end
+

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -46,23 +46,23 @@ describe "Arboreal hierarchy" do
       end
 
       it "is not valid" do
-        @australia.ancestry_string = ''
+        @australia.materialized_path = ''
         @australia.should_not be_valid
-        @australia.ancestry_string = '42'
+        @australia.materialized_path = '42'
         @australia.should_not be_valid
-        @australia.ancestry_string = '42-'
+        @australia.materialized_path = '42-'
         @australia.should_not be_valid
-        @australia.ancestry_string = '--'
+        @australia.materialized_path = '--'
         @australia.should_not be_valid
-        @australia.ancestry_string = '-42'
+        @australia.materialized_path = '-42'
         @australia.should_not be_valid
-        @australia.ancestry_string = '-42-58'
+        @australia.materialized_path = '-42-58'
         @australia.should_not be_valid
-        @australia.ancestry_string = 'not ids'
+        @australia.materialized_path = 'not ids'
         @australia.should_not be_valid
-        @australia.ancestry_string = '\''
+        @australia.materialized_path = '\''
         @australia.should_not be_valid
-        @australia.ancestry_string = '; drop table nodes'
+        @australia.materialized_path = '; drop table nodes'
         @australia.should_not be_valid
       end
     end
@@ -81,9 +81,9 @@ describe "Arboreal hierarchy" do
       end
     end
 
-    describe "#ancestry_string" do
+    describe "#materialized_path" do
       it "is a single dash" do
-        @australia.ancestry_string.should == "-"
+        @australia.materialized_path.should == "-"
       end
     end
 
@@ -133,9 +133,9 @@ describe "Arboreal hierarchy" do
   end
 
   describe "leaf node" do
-    describe "#ancestry_string" do
+    describe "#materialized_path" do
       it "contains ids of all ancestors" do
-        @melbourne.ancestry_string.should == "-#{@australia.id}-#{@victoria.id}-"
+        @melbourne.materialized_path.should == "-#{@australia.id}-#{@victoria.id}-"
       end
     end
 
@@ -209,7 +209,7 @@ describe "Arboreal hierarchy" do
 
   describe "SQL injection protection" do
     before do
-      @melbourne.ancestry_string = 'EVIL \'"SQL INJECTION'
+      @melbourne.materialized_path = 'EVIL \'"SQL INJECTION'
     end
 
     it 'does not cause a SQL injection' do
@@ -221,12 +221,12 @@ describe "Arboreal hierarchy" do
 
   describe ".rebuild_ancestry" do
     before do
-      Node.connection.update("UPDATE nodes SET ancestry_string = 'corrupt'")
+      Node.connection.update("UPDATE nodes SET materialized_path = 'corrupt'")
       Node.rebuild_ancestry
     end
 
-    it "re-populates all ancestry_strings" do
-      Node.count(:conditions => {:ancestry_string => 'corrupt'}).should == 0
+    it "re-populates all materialized_paths" do
+      Node.count(:conditions => {:materialized_path => 'corrupt'}).should == 0
     end
 
     it "fixes the hierarchy" do

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -1,14 +1,6 @@
 require "spec_helper"
 
 describe "Arboreal hierarchy" do
-  before(:each) do
-    Node::Migration.up
-  end
-
-  after(:each) do
-    Node::Migration.down
-  end
-
   before do
     @australia = Node.create!(:name => "Australia")
     @victoria = @australia.children.create!(:name => "Victoria")

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -91,6 +91,10 @@ describe "Arboreal hierarchy" do
       it "contains only the id of the root" do
         @australia.path_string.should == "-#{@australia.id}-"
       end
+
+      it "returns nil for new records" do
+        Node.new.path_string.should be_nil
+      end
     end
 
     describe "#descendants" do

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -69,6 +69,10 @@ describe "Arboreal hierarchy" do
   end
 
   describe "root node" do
+    it "is a root" do
+      @australia.should be_root
+    end
+
     describe "#parent" do
       it "returns nil" do
         @australia.parent.should == nil
@@ -137,6 +141,10 @@ describe "Arboreal hierarchy" do
   end
 
   describe "leaf node" do
+    it "is not a root" do
+      @melbourne.should_not be_root
+    end
+
     describe "#materialized_path" do
       it "contains ids of all ancestors" do
         @melbourne.materialized_path.should == "-#{@australia.id}-#{@victoria.id}-"

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -92,8 +92,8 @@ describe "Arboreal hierarchy" do
         @australia.path_string.should == "-#{@australia.id}-"
       end
 
-      it "returns nil for new records" do
-        Node.new.path_string.should be_nil
+      it "returns '-' for new records" do
+        Node.new.path_string.should == "-"
       end
     end
 

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -252,4 +252,12 @@ describe "Arboreal hierarchy" do
       @sydney.reload.ancestors.should == [@australia, @nsw]
     end
   end
+
+  describe "a newly-created node" do
+    let(:new_node) { Node.new(name: "New node") }
+
+    it "has no ancestor ids" do
+      new_node.ancestor_ids.should be_empty
+    end
+  end
 end

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -39,6 +39,33 @@ describe "Arboreal hierarchy" do
         @australia.update_attributes!(:parent => @melbourne)
       end.should raise_error(ActiveRecord::RecordInvalid)
     end
+
+    describe "ancestry string format" do
+      it "is valid" do
+        @australia.should be_valid
+      end
+
+      it "is not valid" do
+        @australia.ancestry_string = ''
+        @australia.should_not be_valid
+        @australia.ancestry_string = '42'
+        @australia.should_not be_valid
+        @australia.ancestry_string = '42-'
+        @australia.should_not be_valid
+        @australia.ancestry_string = '--'
+        @australia.should_not be_valid
+        @australia.ancestry_string = '-42'
+        @australia.should_not be_valid
+        @australia.ancestry_string = '-42-58'
+        @australia.should_not be_valid
+        @australia.ancestry_string = 'not ids'
+        @australia.should_not be_valid
+        @australia.ancestry_string = '\''
+        @australia.should_not be_valid
+        @australia.ancestry_string = '; drop table nodes'
+        @australia.should_not be_valid
+      end
+    end
   end
 
   describe "root node" do
@@ -177,6 +204,18 @@ describe "Arboreal hierarchy" do
 
     it "still has the right ancestry" do
       @tasmania.ancestors.should == [@australia]
+    end
+  end
+
+  describe "SQL injection protection" do
+    before do
+      @melbourne.ancestry_string = 'EVIL \'"SQL INJECTION'
+    end
+
+    it 'does not cause a SQL injection' do
+      lambda {
+        @melbourne.save(validate: false)
+      }.should_not raise_error
     end
   end
 

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -201,6 +201,20 @@ describe "Arboreal hierarchy" do
     end
   end
 
+  describe "when a node becomes a root" do
+    before do
+      @victoria.update_attribute(:parent_id, nil)
+    end
+
+    it "no longer has ancestors" do
+      @victoria.ancestors.should be_empty
+    end
+
+    it "persists changes to the ancestors" do
+      @victoria.reload.ancestors.should be_empty
+    end
+  end
+
   describe "node created using find_or_create_by" do
     before do
       @tasmania = @australia.children.find_or_create_by_name("Tasmania")

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -1,25 +1,4 @@
-require 'spec_helper'
-
-require 'arboreal'
-
-class Node < ActiveRecord::Base
-  acts_arboreal
-
-  class Migration < ActiveRecord::Migration
-    def self.up
-      create_table "nodes", :force => true do |t|
-        t.string "name"
-        t.string "type"
-        t.integer "parent_id"
-        t.string "ancestry_string"
-      end
-    end
-
-    def self.down
-      drop_table "nodes"
-    end
-  end
-end
+require "spec_helper"
 
 describe "Arboreal hierarchy" do
   before(:each) do
@@ -128,9 +107,9 @@ describe "Arboreal hierarchy" do
     end
 
     describe "#root" do
-     it "is itself" do
-       @australia.root.should == @australia
-     end
+      it "is itself" do
+        @australia.root.should == @australia
+      end
     end
   end
 
@@ -222,44 +201,6 @@ describe "Arboreal hierarchy" do
     it "fixes the hierarchy" do
       @melbourne.reload.ancestors.should == [@australia, @victoria]
       @sydney.reload.ancestors.should == [@australia, @nsw]
-    end
-  end
-end
-
-class RedNode < Node; end
-class GreenNode < Node; end
-class BlueNode < Node; end
-
-describe "polymorphic hierarchy" do
-  before(:each) do
-    Node::Migration.up
-  end
-
-  after(:each) do
-    Node::Migration.down
-  end
-
-  before do
-    @red = RedNode.create!
-    @green = GreenNode.create!(:parent => @red)
-    @blue = BlueNode.create!(:parent => @green)
-  end
-
-  describe "#descendants" do
-    it "includes nodes of other types" do
-      @red.descendants.should include(@green, @blue)
-    end
-  end
-
-  describe "#subtree" do
-    it "includes nodes of other types" do
-      @red.subtree.should include(@red, @green, @blue)
-    end
-  end
-
-  describe "#ancestors" do
-    it "includes nodes of other types" do
-      @blue.ancestors.should include(@red, @green)
     end
   end
 end

--- a/spec/polymorphic_hierarchy_spec.rb
+++ b/spec/polymorphic_hierarchy_spec.rb
@@ -1,14 +1,6 @@
 require 'spec_helper'
 
 describe "polymorphic hierarchy" do
-  before(:each) do
-    Node::Migration.up
-  end
-
-  after(:each) do
-    Node::Migration.down
-  end
-
   before do
     @red = RedNode.create!
     @green = GreenNode.create!(:parent => @red)

--- a/spec/polymorphic_hierarchy_spec.rb
+++ b/spec/polymorphic_hierarchy_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe "polymorphic hierarchy" do
+  before(:each) do
+    Node::Migration.up
+  end
+
+  after(:each) do
+    Node::Migration.down
+  end
+
+  before do
+    @red = RedNode.create!
+    @green = GreenNode.create!(:parent => @red)
+    @blue = BlueNode.create!(:parent => @green)
+  end
+
+  describe "#descendants" do
+    it "includes nodes of other types" do
+      @red.descendants.should include(@green, @blue)
+    end
+  end
+
+  describe "#subtree" do
+    it "includes nodes of other types" do
+      @red.subtree.should include(@red, @green, @blue)
+    end
+  end
+
+  describe "#ancestors" do
+    it "includes nodes of other types" do
+      @blue.ancestors.should include(@red, @green)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,32 +9,6 @@ FileUtils.mkdir_p("tmp")
 ActiveRecord::Base.logger = Logger.new("tmp/test.log")
 ActiveRecord::Base.logger.level = Logger::DEBUG
 
-ActiveRecord::Schema.verbose = false
-
-DB_CONFIGS = {
-  "sqlite3" => {
-    :database => 'tmp/test.sqlite'
-  },
-  "mysql" => {
-    :host     => 'localhost',
-    :database => 'weblog_development',
-    :username => 'blog',
-    :password => ''
-  },
-  "postgresql" => {
-    :host     => 'localhost',
-    :database => 'weblog_development',
-  },
-  "jdbcmssql" => {
-    :host     => 'localhost',
-    :port     => 1433,
-    :database => 'weblog_development',
-    :username => 'blog',
-    :password => ''
-  }
-}
-
-test_adapter = (ENV["AR_ADAPTER"] || "sqlite3")
-test_db_config = DB_CONFIGS[test_adapter].merge(:adapter => test_adapter)
-
-ActiveRecord::Base.establish_connection(test_db_config)
+require_relative "support/db"
+require "arboreal"
+require_relative "support/node"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,3 +12,13 @@ ActiveRecord::Base.logger.level = Logger::DEBUG
 require_relative "support/db"
 require "arboreal"
 require_relative "support/node"
+
+RSpec.configure do |c|
+  c.before(:each) do
+    Node::Migration.up
+  end
+
+  c.after(:each) do
+    Node::Migration.down
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-require 'spec'
-
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 

--- a/spec/support/db.rb
+++ b/spec/support/db.rb
@@ -1,0 +1,29 @@
+ActiveRecord::Schema.verbose = false
+
+DB_CONFIGS = {
+  "sqlite3" => {
+    :database => 'tmp/test.sqlite'
+  },
+  "mysql" => {
+    :host     => 'localhost',
+    :database => 'weblog_development',
+    :username => 'blog',
+    :password => ''
+  },
+  "postgresql" => {
+    :host     => 'localhost',
+    :database => 'weblog_development',
+  },
+  "jdbcmssql" => {
+    :host     => 'localhost',
+    :port     => 1433,
+    :database => 'weblog_development',
+    :username => 'blog',
+    :password => ''
+  }
+}
+
+test_adapter = (ENV["AR_ADAPTER"] || "sqlite3")
+test_db_config = DB_CONFIGS[test_adapter].merge(:adapter => test_adapter)
+
+ActiveRecord::Base.establish_connection(test_db_config)

--- a/spec/support/node.rb
+++ b/spec/support/node.rb
@@ -1,0 +1,24 @@
+require 'arboreal'
+
+class Node < ActiveRecord::Base
+  acts_arboreal
+
+  class Migration < ActiveRecord::Migration
+    def self.up
+      create_table "nodes", :force => true do |t|
+        t.string "name"
+        t.string "type"
+        t.integer "parent_id"
+        t.string "ancestry_string"
+      end
+    end
+
+    def self.down
+      drop_table "nodes"
+    end
+  end
+end
+
+class RedNode < Node; end
+class GreenNode < Node; end
+class BlueNode < Node; end

--- a/spec/support/node.rb
+++ b/spec/support/node.rb
@@ -9,7 +9,7 @@ class Node < ActiveRecord::Base
         t.string "name"
         t.string "type"
         t.integer "parent_id"
-        t.string "ancestry_string"
+        t.string "materialized_path"
       end
     end
 


### PR DESCRIPTION
This is a fairly large PR that contains a number of upgrades that @cantino made to this somewhat outdated gem:
- Upgrade to rspec 2.10 to match what we use on bigmaven
- Upgrade to Rails 3+ only (dropping support for Rails 2)
- Upgrade to Ruby 1.9.3+ only (dropping support for 1.8.7)
- Split the specs into separate files
- Allow the parent and child relations to be customized with new options
- Protect against SQL injection
- Rename `ancestry_string` to `materialized_path` to avoid confusion with the ancestry gem
- Write more specs around trees of unsaved objects, and fix a few bugs that we found with them

@bobby1190 @shirish-pampoorickal: Can you look this over and see what you think?
