### PR TITLE
Update root_ancestor_id of descendants when parent is made a root

### DIFF
--- a/lib/arboreal/instance_methods.rb
+++ b/lib/arboreal/instance_methods.rb
@@ -115,7 +115,7 @@ module Arboreal
 
     def descendant_attributes_to_update(old_path_string)
       if root_relation_enabled?
-        ["root_ancestor_id = ?, materialized_path = REPLACE(materialized_path, ?, ?)", root_ancestor_id, old_path_string, path_string]
+        ["root_ancestor_id = ?, materialized_path = REPLACE(materialized_path, ?, ?)", root_ancestor_id || id, old_path_string, path_string]
       else
         ["materialized_path = REPLACE(materialized_path, ?, ?)", old_path_string, path_string]
       end

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -240,6 +240,7 @@ describe "Arboreal hierarchy" do
 
   describe "when a node becomes a root" do
     before do
+      Node.create!(:name => "Southbank", :parent => @melbourne)
       @victoria.update_attribute(:parent_id, nil)
     end
 
@@ -253,6 +254,10 @@ describe "Arboreal hierarchy" do
 
     it "persists changes to the ancestors" do
       @victoria.reload.ancestors.should be_empty
+    end
+
+    it 'updates the root of its descendants' do
+      @victoria.descendants.pluck('DISTINCT root_ancestor_id').should == [@victoria.id]
     end
   end
 

--- a/spec/hierarchy_spec.rb
+++ b/spec/hierarchy_spec.rb
@@ -257,7 +257,7 @@ describe "Arboreal hierarchy" do
     end
 
     it 'updates the root of its descendants' do
-      @victoria.descendants.pluck('DISTINCT root_ancestor_id').should == [@victoria.id]
+      @victoria.descendants.map(&:root_ancestor).uniq.should == [@victoria]
     end
   end
 


### PR DESCRIPTION
Issue: When changing a child node with descendants to a root, the root_ancestor_id for all the descendants would be set to nil.

@naiyt @urnf Appreciate a look
