### PR TITLE
A new record should not have descendants

### DIFF
--- a/lib/arboreal/instance_methods.rb
+++ b/lib/arboreal/instance_methods.rb
@@ -69,6 +69,7 @@ module Arboreal
     end
 
     def descendant_conditions
+      return ["1 = 0"] if new_record?
       ["#{table_name}.materialized_path LIKE ?", path_string + "%"]
     end
 


### PR DESCRIPTION
The current behavior is that a new record will have all stories in the entire database as descendants

- Rick and Gerald

Fixes https://github.com/mavenlink/mavenlink/pull/7412